### PR TITLE
Performance improvements

### DIFF
--- a/benchmarks/elm.json
+++ b/benchmarks/elm.json
@@ -1,0 +1,30 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src",
+        "../src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm-explorations/benchmark": "1.0.2"
+        },
+        "indirect": {
+            "BrianHicks/elm-trend": "2.1.3",
+            "elm/json": "1.1.3",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.3",
+            "mdgriffith/style-elements": "5.0.2",
+            "robinheghan/murmur3": "1.0.0"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -62,6 +62,11 @@ suite =
             (\() -> Stat.variance numbers)
             "Old"
             (\() -> variance numbers)
+        , Benchmark.compare "Skewness"
+            "New"
+            (\() -> Stat.skewness numbers)
+            "Old"
+            (\() -> skewness numbers)
         , Benchmark.compare "RMS: single VS multiple traversals"
             "New"
             (\() -> Stat.rootMeanSquare numbers)
@@ -163,6 +168,24 @@ geometricMean list =
     else
         List.product list ^ (1 / toFloat l) |> Just
 
+
+skewness : List Float -> Maybe Float
+skewness list =
+    let
+        stdDev =
+            standardDeviation list
+    in
+    case stdDev of
+        Nothing ->
+            Nothing
+
+        Just s ->
+            mean list
+                |> Maybe.andThen
+                    (\n ->
+                        List.map (\x -> ((x - n) / s) ^ 3) list
+                            |> mean
+                    )
 
 variance : List Float -> Maybe Float
 variance list =

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -16,6 +16,11 @@ suite =
         numbers : List Float
         numbers =
             List.range 0 1000 |> List.map toFloat 
+
+        weightedNumbers : List (Float, Float)
+        weightedNumbers =
+            List.foldl (\el (w, acc) -> ( w + 0.05, ( w, el )  :: acc )) (0.05, []) numbers
+                |> Tuple.second
     in
     describe "elm-stat"
         [ describe "Mean"
@@ -24,32 +29,56 @@ suite =
                 (\() -> Stat.mean numbers)
                 "List.sum / List.length"
                 (\() -> List.sum numbers / toFloat (List.length numbers))
-            , let 
-                oldMean : List Float -> Maybe Float
-                oldMean list =
-                    let
-                        ( sum, len ) =
-                            sumLen list
-                    in
-                    if len == 0 then
-                        Nothing
-
-                    else
-                        sum / toFloat len |> Just
-
-
-                sumLen : List Float -> ( Float, Int )
-                sumLen =
-                    List.foldl 
-                        (\x y -> 
-                            Tuple.pair (Tuple.first y + x) (Tuple.second y + 1)
-                        ) 
-                        ( 0, 0 ) 
-             in
-             Benchmark.compare "Tail call recursion VS foldl + tuple"
+            , Benchmark.compare "Tail call recursion VS foldl + tuple"
                 "Tail call"
                 (\() -> Stat.mean numbers)
                 "Foldl + tuple"
-                (\() -> oldMean numbers)
+                (\() -> mean numbers)
+            ]
+        , describe "Weighted mean"
+            [ Benchmark.compare "Single VS multiple traversals"
+                "New"
+                (\() -> Stat.weightedMean weightedNumbers)
+                "Old"
+                (\() -> weightedMean weightedNumbers)
             ]
         ]
+
+
+
+-- Old versions
+
+
+mean : List Float -> Maybe Float
+mean list =
+    let
+        ( sum, len ) =
+            sumLen list
+    in
+    if len == 0 then
+        Nothing
+
+    else
+        sum / toFloat len |> Just
+
+
+
+sumLen : List Float -> ( Float, Int )
+sumLen =
+    List.foldl (\x y -> Tuple.pair (Tuple.first y + x) (Tuple.second y + 1)) 
+        ( 0, 0 ) 
+
+
+weightedMean : List ( Float, Float ) -> Maybe Float
+weightedMean tupleList =
+    let
+        wSum =
+            List.map (\t -> Tuple.first t) tupleList |> List.sum
+    in
+    if wSum == 0 then
+        Nothing
+
+    else
+        (List.map (\t -> Tuple.first t * Tuple.second t) tupleList |> List.sum) 
+            / wSum 
+            |> Just

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -38,6 +38,11 @@ suite =
             (\() -> Stat.harmonicMean numbers)
             "Old"
             (\() -> harmonicMean numbers)
+        , Benchmark.compare "Geometric mean: single VS multiple traversals"
+            "New"
+            (\() -> Stat.geometricMean numbers)
+            "Old"
+            (\() -> geometricMean numbers)
         ]
         
 
@@ -91,3 +96,16 @@ harmonicMean list =
         Nothing
     else
         toFloat (List.length list) / sum |> Just
+
+        
+geometricMean : List Float -> Maybe Float
+geometricMean list =
+    let
+        l =
+            List.length list
+    in
+    if l == 0 then
+        Nothing
+
+    else
+        List.product list ^ (1 / toFloat l) |> Just

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -15,7 +15,7 @@ suite =
     let
         numbers : List Float
         numbers =
-            List.range 0 1000 |> List.map toFloat 
+            List.range 1 1000 |> List.map toFloat 
 
         weightedNumbers : List (Float, Float)
         weightedNumbers =
@@ -23,26 +23,23 @@ suite =
                 |> Tuple.second
     in
     describe "elm-stat"
-        [ describe "Mean"
-            [ Benchmark.compare "Stat.mean VS naive mean"
-                "Stat.mean"
-                (\() -> Stat.mean numbers)
-                "List.sum / List.length"
-                (\() -> List.sum numbers / toFloat (List.length numbers))
-            , Benchmark.compare "Tail call recursion VS foldl + tuple"
-                "Tail call"
-                (\() -> Stat.mean numbers)
-                "Foldl + tuple"
-                (\() -> mean numbers)
-            ]
-        , describe "Weighted mean"
-            [ Benchmark.compare "Single VS multiple traversals"
-                "New"
-                (\() -> Stat.weightedMean weightedNumbers)
-                "Old"
-                (\() -> weightedMean weightedNumbers)
-            ]
+        [ Benchmark.compare "Mean: tail call recursion VS foldl + tuple"
+            "New"
+            (\() -> Stat.mean numbers)
+            "Old"
+            (\() -> mean numbers)
+        , Benchmark.compare "Weighted mean: single VS multiple traversals"
+            "New"
+            (\() -> Stat.weightedMean weightedNumbers)
+            "Old"
+            (\() -> weightedMean weightedNumbers)
+        , Benchmark.compare "Harmonic mean: single VS multiple traversals"
+            "New"
+            (\() -> Stat.harmonicMean numbers)
+            "Old"
+            (\() -> harmonicMean numbers)
         ]
+        
 
 
 
@@ -82,3 +79,15 @@ weightedMean tupleList =
         (List.map (\t -> Tuple.first t * Tuple.second t) tupleList |> List.sum) 
             / wSum 
             |> Just
+
+
+harmonicMean : List Float -> Maybe Float
+harmonicMean list = 
+    let
+        sum =
+            List.sum (List.map (\x -> x ^ -1) list)
+    in
+    if sum == 0 then
+        Nothing
+    else
+        toFloat (List.length list) / sum |> Just

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -62,6 +62,11 @@ suite =
             (\() -> Stat.variance numbers)
             "Old"
             (\() -> variance numbers)
+        , Benchmark.compare "RMS: single VS multiple traversals"
+            "New"
+            (\() -> Stat.rootMeanSquare numbers)
+            "Old"
+            (\() -> rootMeanSquare numbers)
         ]
         
 
@@ -159,3 +164,19 @@ mode list =
         |> Maybe.map Tuple.first
         |> (\x -> ( x, maxValue ))
         |> combineTuple
+
+rootMeanSquare : List Float -> Maybe Float
+rootMeanSquare list =
+    let
+        l =
+            List.length list
+    in
+    if l == 0 then
+        Nothing
+
+    else
+        List.map (\x -> x ^ 2) list
+            |> List.sum
+            |> (\x -> x / toFloat l)
+            |> sqrt
+            |> Just

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -82,6 +82,11 @@ suite =
             (\() -> Stat.zScores numbers)
             "Old"
             (\() -> zScores numbers)
+        , Benchmark.compare "Covariance"
+            "New"
+            (\() -> Stat.covariance <| List.map2 Tuple.pair numbers numbers)
+            "Old"
+            (\() -> covariance <| List.map2 Tuple.pair numbers numbers)
         ]
         
 
@@ -241,8 +246,19 @@ median list =
             |> List.drop (l // 2)
             |> List.head
 
+
 zScores : List Float -> Maybe (List Float)
 zScores list =
     Maybe.map2 (\avg stdDev -> List.map (\x -> (x - avg) / stdDev) list) 
         (mean list) 
         (standardDeviation list)
+
+        
+covariance : List ( Float, Float ) -> Maybe Float
+covariance tupleList =
+    let
+        ( xs, ys ) =
+            List.unzip tupleList
+    in
+    Maybe.map2 (\mxs mys -> List.map2 (\x y -> (x - mxs) * (y - mys)) xs ys) (mean xs) (mean ys)
+        |> Maybe.andThen mean

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -1,0 +1,55 @@
+module Benchmarks exposing (main)
+
+import Benchmark exposing (describe, Benchmark)
+import Benchmark.Runner exposing (BenchmarkProgram, program)
+import Stat
+
+
+main : BenchmarkProgram
+main =
+    program suite
+
+
+suite : Benchmark
+suite =
+    let
+        numbers : List Float
+        numbers =
+            List.range 0 1000 |> List.map toFloat 
+    in
+    describe "elm-stat"
+        [ describe "Mean"
+            [ Benchmark.compare "Stat.mean VS naive mean"
+                "Stat.mean"
+                (\() -> Stat.mean numbers)
+                "List.sum / List.length"
+                (\() -> List.sum numbers / toFloat (List.length numbers))
+            , let 
+                oldMean : List Float -> Maybe Float
+                oldMean list =
+                    let
+                        ( sum, len ) =
+                            sumLen list
+                    in
+                    if len == 0 then
+                        Nothing
+
+                    else
+                        sum / toFloat len |> Just
+
+
+                sumLen : List Float -> ( Float, Int )
+                sumLen =
+                    List.foldl 
+                        (\x y -> 
+                            Tuple.pair (Tuple.first y + x) (Tuple.second y + 1)
+                        ) 
+                        ( 0, 0 ) 
+             in
+             Benchmark.compare "Tail call recursion VS foldl + tuple"
+                "Tail call"
+                (\() -> Stat.mean numbers)
+                "Foldl + tuple"
+                (\() -> oldMean numbers)
+            ]
+        ]

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -43,6 +43,11 @@ suite =
             (\() -> Stat.geometricMean numbers)
             "Old"
             (\() -> geometricMean numbers)
+        , Benchmark.compare "Variance: single VS multiple traversals"
+            "New"
+            (\() -> Stat.variance numbers)
+            "Old"
+            (\() -> variance numbers)
         ]
         
 
@@ -109,3 +114,14 @@ geometricMean list =
 
     else
         List.product list ^ (1 / toFloat l) |> Just
+
+
+        
+variance : List Float -> Maybe Float
+variance list =
+    mean list
+        |> Maybe.andThen
+            (\n ->
+                List.map (\x -> (x - n) ^ 2) list
+                    |> mean
+            )

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -92,6 +92,11 @@ suite =
             (\() -> Stat.correlation <| List.map2 Tuple.pair numbers numbers)
             "Old"
             (\() -> correlation <| List.map2 Tuple.pair numbers numbers)
+        , Benchmark.compare "Linear Regression"
+            "New"
+            (\() -> Stat.linearRegression <| List.map2 Tuple.pair numbers numbers)
+            "Old"
+            (\() -> linearRegression <| List.map2 Tuple.pair numbers numbers)
         ]
 
 
@@ -273,3 +278,26 @@ correlation tupleList =
             List.unzip tupleList
     in
     Maybe.map3 (\cov stdDevXs stdDevYs -> cov / (stdDevXs * stdDevYs)) (covariance tupleList) (standardDeviation xs) (standardDeviation ys)
+
+
+linearRegression : List ( Float, Float ) -> Maybe ( Float, Float )
+linearRegression tupleList =
+    if List.length tupleList > 1 then
+        let
+            ( xs, ys ) =
+                List.unzip tupleList
+
+            cov =
+                covariance tupleList |> Maybe.withDefault 0
+
+            varxs =
+                variance xs |> Maybe.withDefault 0
+        in
+        if varxs /= 0 then
+            Maybe.map2 (\mxs mys -> Tuple.pair (mys - (cov / varxs) * mxs) (cov / varxs)) (mean xs) (mean ys)
+
+        else
+            Nothing
+
+    else
+        Nothing

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -72,6 +72,11 @@ suite =
             (\() -> Stat.meanAbsoluteDeviation numbers)
             "Old"
             (\() -> meanAbsoluteDeviation numbers)
+        , Benchmark.compare "Median absolute deviation"
+            "New"
+            (\() -> Stat.medianAbsoluteDeviation numbers)
+            "Old"
+            (\() -> medianAbsoluteDeviation numbers)
         ]
         
 
@@ -196,3 +201,32 @@ meanAbsoluteDeviation list =
             (\n ->
                 List.map (\x -> abs (x - n)) list |> mean
             )
+
+
+medianAbsoluteDeviation : List Float -> Maybe Float
+medianAbsoluteDeviation list =
+    median list
+        |> Maybe.andThen
+            (\n ->
+                List.map (\x -> abs (x - n)) list |> mean
+            )
+
+median : List Float -> Maybe Float
+median list =
+    let
+        l =
+            List.length list
+    in
+    if l == 0 then
+        Nothing
+
+    else if modBy 2 l == 0 then
+        List.sort list
+            |> List.drop ((l // 2) - 1)
+            |> List.take 2
+            |> mean
+
+    else
+        List.sort list
+            |> List.drop (l // 2)
+            |> List.head

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -77,6 +77,11 @@ suite =
             (\() -> Stat.medianAbsoluteDeviation numbers)
             "Old"
             (\() -> medianAbsoluteDeviation numbers)
+        , Benchmark.compare "zScores"
+            "New"
+            (\() -> Stat.zScores numbers)
+            "Old"
+            (\() -> zScores numbers)
         ]
         
 
@@ -156,6 +161,11 @@ variance list =
             )
 
 
+standardDeviation : List Float -> Maybe Float
+standardDeviation =
+    variance >> Maybe.map sqrt
+
+    
 
 mode : List comparable -> Maybe ( comparable, Int )
 mode list =
@@ -230,3 +240,9 @@ median list =
         List.sort list
             |> List.drop (l // 2)
             |> List.head
+
+zScores : List Float -> Maybe (List Float)
+zScores list =
+    Maybe.map2 (\avg stdDev -> List.map (\x -> (x - avg) / stdDev) list) 
+        (mean list) 
+        (standardDeviation list)

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -67,6 +67,11 @@ suite =
             (\() -> Stat.rootMeanSquare numbers)
             "Old"
             (\() -> rootMeanSquare numbers)
+        , Benchmark.compare "Mean absolute deviation"
+            "New"
+            (\() -> Stat.meanAbsoluteDeviation numbers)
+            "Old"
+            (\() -> meanAbsoluteDeviation numbers)
         ]
         
 
@@ -165,6 +170,8 @@ mode list =
         |> (\x -> ( x, maxValue ))
         |> combineTuple
 
+
+
 rootMeanSquare : List Float -> Maybe Float
 rootMeanSquare list =
     let
@@ -180,3 +187,12 @@ rootMeanSquare list =
             |> (\x -> x / toFloat l)
             |> sqrt
             |> Just
+
+
+meanAbsoluteDeviation : List Float -> Maybe Float
+meanAbsoluteDeviation list =
+    mean list
+        |> Maybe.andThen
+            (\n ->
+                List.map (\x -> abs (x - n)) list |> mean
+            )

--- a/elm.json
+++ b/elm.json
@@ -25,6 +25,6 @@
         "zgohr/elm-csv": "1.0.1 <= v < 2.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "1.1.0 <= v < 2.0.0"
+        "elm-explorations/test": "2.1.2 <= v < 3.0.0"
     }
 }

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -282,12 +282,22 @@ skewness list =
 -}
 variance : List Float -> Maybe Float
 variance list =
-    mean list
-        |> Maybe.andThen
-            (\n ->
-                List.map (\x -> (x - n) ^ 2) list
-                    |> mean
-            )
+    case list of
+        [] ->
+            Nothing
+
+        x :: xs ->
+            Just (varianceHelp xs (x ^ 2) x 1)
+
+
+varianceHelp : List Float -> Float -> Float -> Float -> Float
+varianceHelp remaining squaredSum sum length =
+    case remaining of
+        [] ->
+            squaredSum / length - (sum / length) ^ 2
+
+        x :: xs ->
+            varianceHelp xs (squaredSum + x ^ 2) (sum + x) (length + 1)
 
 
 {-| The standard deviation is the square root of variance. A low standard deviation indicates that the values tend to be close to the mean.

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -308,21 +308,46 @@ rootMeanSquareHelp remaining total length =
 -}
 skewness : List Float -> Maybe Float
 skewness list =
-    let
-        stdDev =
-            standardDeviation list
-    in
-    case stdDev of
-        Nothing ->
+    case list of
+        [] ->
             Nothing
 
-        Just s ->
-            mean list
-                |> Maybe.andThen
-                    (\n ->
-                        List.map (\x -> ((x - n) / s) ^ 3) list
-                            |> mean
-                    )
+        x :: xs ->
+            let
+                data =
+                    skewnessHelp1 xs (x ^ 2) x 1
+            in
+            skewnessHelp2 xs data.mean data.stdDev (((x - data.mean) / data.stdDev) ^ 3)
+                / data.length
+                |> Just
+
+
+skewnessHelp1 :
+    List Float
+    -> Float
+    -> Float
+    -> Float
+    -> { mean : Float, stdDev : Float, length : Float }
+skewnessHelp1 remaining squaredSum sum length =
+    case remaining of
+        [] ->
+            { mean = sum / length
+            , stdDev = squaredSum / length - (sum / length) ^ 2 |> sqrt
+            , length = length
+            }
+
+        x :: xs ->
+            skewnessHelp1 xs (squaredSum + x ^ 2) (sum + x) (length + 1)
+
+
+skewnessHelp2 : List Float -> Float -> Float -> Float -> Float
+skewnessHelp2 remaining m s acc =
+    case remaining of
+        [] ->
+            acc
+
+        x :: xs ->
+            skewnessHelp2 xs m s (acc + ((x - m) / s) ^ 3)
 
 
 {-| In statistics, variance is the expectation of the squared deviation of a random variable from its mean.

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -123,15 +123,26 @@ weightedMeanHelp remaining totalWeight weightedSum =
 -}
 harmonicMean : List Float -> Maybe Float
 harmonicMean list =
-    let
-        sum =
-            List.sum (List.map (\x -> x ^ -1) list)
-    in
-    if sum == 0 then
-        Nothing
+    case list of
+        [] ->
+            Nothing
 
-    else
-        toFloat (List.length list) / sum |> Just
+        x :: xs ->
+            harmonicMeanHelp xs (1 / x) 1
+
+
+harmonicMeanHelp : List Float -> Float -> Float -> Maybe Float
+harmonicMeanHelp remaining inverseSum length =
+    case remaining of
+        [] ->
+            if inverseSum == 0 then
+                Nothing
+
+            else
+                Just (length / inverseSum)
+
+        x :: xs ->
+            harmonicMeanHelp xs (inverseSum + 1 / x) (length + 1)
 
 
 {-| Compute the geometric mean of a list of floats.

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -376,11 +376,17 @@ meanAbsoluteDeviationHelp remaining avg total length =
 -}
 medianAbsoluteDeviation : List Float -> Maybe Float
 medianAbsoluteDeviation list =
-    median list
-        |> Maybe.andThen
-            (\n ->
-                List.map (\x -> abs (x - n)) list |> mean
-            )
+    case list of
+        [] ->
+            Nothing
+
+        x :: xs ->
+            case median list of
+                Just mdn ->
+                    Just (meanAbsoluteDeviationHelp xs mdn (abs (mdn - x)) 1)
+
+                _ ->
+                    Nothing
 
 
 {-| Calculate the Z-score or standard score of a given elements provided the mean and the standard deviation.

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -274,24 +274,6 @@ lengthHelp remaining total =
             lengthHelp xs (total + 1)
 
 
-
--- let
---     l =
---         List.length list
--- in
--- if l == 0 then
---     Nothing
--- else if modBy 2 l == 0 then
---     List.sort list
---         |> List.drop ((l // 2) - 1)
---         |> List.take 2
---         |> mean
--- else
---     List.sort list
---         |> List.drop (l // 2)
---         |> List.head
-
-
 {-| Root mean square (RMS) is the square root of the sum of the squares of values in a list divided by the length of the list. Also known as quadratic mean.
 
     Stat.rootMeanSquare [ 1, 10, 20 ] == Just 12.92

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -345,11 +345,28 @@ standardDeviation =
 -}
 meanAbsoluteDeviation : List Float -> Maybe Float
 meanAbsoluteDeviation list =
-    mean list
-        |> Maybe.andThen
-            (\n ->
-                List.map (\x -> abs (x - n)) list |> mean
-            )
+    case list of
+        [] ->
+            Nothing
+
+        x :: xs ->
+            Just <|
+                let
+                    avg : Float
+                    avg =
+                        meanHelp xs x 1
+                in
+                meanAbsoluteDeviationHelp xs avg (abs (avg - x)) 1
+
+
+meanAbsoluteDeviationHelp : List Float -> Float -> Float -> Float -> Float
+meanAbsoluteDeviationHelp remaining avg total length =
+    case remaining of
+        [] ->
+            total / length
+
+        x :: xs ->
+            meanAbsoluteDeviationHelp xs avg (total + abs (avg - x)) (length + 1)
 
 
 {-| The median absolute deviation, of a data set is the average of the absolute deviations from the median.

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -78,11 +78,7 @@ average =
 -}
 meanWithDefault : List Float -> Float -> Float
 meanWithDefault list defaultValue =
-    let
-        avg =
-            mean list
-    in
-    case avg of
+    case mean list of
         Nothing ->
             defaultValue
 

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -29,9 +29,6 @@ module Stat exposing
 
 -}
 
-import Dict
-import Utility exposing (buildTable, combineTuple)
-
 
 {-| Compute the mean of a list of floats.
 
@@ -226,22 +223,6 @@ modeHelp2 rest best bestFreq new newFreq =
                 modeHelp2 xs best bestFreq x 1
 
 
-
--- let
---     frequencyTable =
---         buildTable list
---     maxValue =
---         List.maximum (Dict.values frequencyTable)
---     kvList =
---         Dict.toList frequencyTable
--- in
--- List.filter (\( _, v ) -> Just v == maxValue) kvList
---     |> List.head
---     |> Maybe.map Tuple.first
---     |> (\x -> ( x, maxValue ))
---     |> combineTuple
-
-
 {-| Compute the median of the list. The median is the value separating the higher half from the lower half of a data sample. If the sample has an odd number of values, the median is the value in the middle. If the sample has an even number of values, the median is the mean of the two middle values.
 
     > Stat.median [1,6,10] == Just 6
@@ -276,19 +257,22 @@ median list =
 -}
 rootMeanSquare : List Float -> Maybe Float
 rootMeanSquare list =
-    let
-        l =
-            List.length list
-    in
-    if l == 0 then
-        Nothing
+    case list of
+        [] ->
+            Nothing
 
-    else
-        List.map (\x -> x ^ 2) list
-            |> List.sum
-            |> (\x -> x / toFloat l)
-            |> sqrt
-            |> Just
+        x :: xs ->
+            Just (rootMeanSquareHelp xs (x ^ 2) 1)
+
+
+rootMeanSquareHelp : List Float -> Float -> Float -> Float
+rootMeanSquareHelp remaining total length =
+    case remaining of
+        [] ->
+            sqrt (total / length)
+
+        x :: xs ->
+            rootMeanSquareHelp xs (total + x ^ 2) (length + 1)
 
 
 {-| Skew or Skewness is a measure of the asymmetry of the probability distribution of a variable around its mean. There are several equations to calculate skewness. The one used in this function is [Pearson’s moment coefficient](https://en.wikipedia.org/wiki/Pearson_correlation_coefficient) of skewness.

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -357,8 +357,13 @@ varianceHelp remaining squaredSum sum length =
 
 -}
 standardDeviation : List Float -> Maybe Float
-standardDeviation =
-    variance >> Maybe.map sqrt
+standardDeviation list =
+    case list of
+        [] ->
+            Nothing
+
+        x :: xs ->
+            Just (varianceHelp xs (x ^ 2) x 1 |> sqrt)
 
 
 {-| The average absolute deviation, or mean absolute deviation, of a data set is the average of the absolute deviations from the mean.

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -439,6 +439,10 @@ zScores list =
                 |> Just
 
 
+
+-- The reversed argument is to take advantage of the reverse & map pattern in zScoresHelp2
+
+
 zScoresHelp1 : List Float -> Float -> Float -> Float -> List Float -> List Float
 zScoresHelp1 remaining squaredSum sum length reversed =
     case remaining of

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -188,7 +188,7 @@ mode list =
             Just (modeHelp1 xs x 1)
 
 
-modeHelp1 : List b -> b -> number -> ( b, number )
+modeHelp1 : List a -> a -> number -> ( a, number )
 modeHelp1 rest element frequency =
     case rest of
         [] ->
@@ -202,7 +202,7 @@ modeHelp1 rest element frequency =
                 modeHelp2 xs element frequency x 1
 
 
-modeHelp2 : List b -> b -> number -> b -> number -> ( b, number )
+modeHelp2 : List a -> a -> number -> a -> number -> ( a, number )
 modeHelp2 rest best bestFreq new newFreq =
     case rest of
         [] ->

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -539,6 +539,14 @@ correlation tupleList =
                 |> Just
 
 
+correlationHelp1 :
+    List ( Float, Float )
+    -> Float
+    -> Float
+    -> Float
+    -> Float
+    -> Float
+    -> { meanA : Float, meanB : Float, varA : Float, varB : Float, length : Float }
 correlationHelp1 remaining squaredA sumA squaredB sumB length =
     case remaining of
         [] ->

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -94,15 +94,26 @@ meanWithDefault list defaultValue =
 -}
 weightedMean : List ( Float, Float ) -> Maybe Float
 weightedMean tupleList =
-    let
-        wSum =
-            List.map (\t -> Tuple.first t) tupleList |> List.sum
-    in
-    if wSum == 0 then
-        Nothing
+    case tupleList of
+        [] ->
+            Nothing
 
-    else
-        (List.map (\t -> Tuple.first t * Tuple.second t) tupleList |> List.sum) / wSum |> Just
+        ( w, x ) :: xs ->
+            weightedMeanHelp xs w (w * x)
+
+
+weightedMeanHelp : List ( Float, Float ) -> Float -> Float -> Maybe Float
+weightedMeanHelp remaining totalWeight weightedSum =
+    case remaining of
+        [] ->
+            if totalWeight == 0 then
+                Nothing
+
+            else
+                Just (weightedSum / totalWeight)
+
+        ( w, x ) :: xs ->
+            weightedMeanHelp xs (totalWeight + w) (weightedSum + w * x)
 
 
 {-| Compute the harmonic mean of a list of floats.

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -183,21 +183,63 @@ geometricMeanHelp remaining product length =
 -}
 mode : List comparable -> Maybe ( comparable, Int )
 mode list =
-    let
-        frequencyTable =
-            buildTable list
+    case List.sort list of
+        [] ->
+            Nothing
 
-        maxValue =
-            List.maximum (Dict.values frequencyTable)
+        x :: xs ->
+            Just (modeHelp1 xs x 1)
 
-        kvList =
-            Dict.toList frequencyTable
-    in
-    List.filter (\( _, v ) -> Just v == maxValue) kvList
-        |> List.head
-        |> Maybe.map Tuple.first
-        |> (\x -> ( x, maxValue ))
-        |> combineTuple
+
+modeHelp1 : List b -> b -> number -> ( b, number )
+modeHelp1 rest element frequency =
+    case rest of
+        [] ->
+            ( element, frequency )
+
+        x :: xs ->
+            if x == element then
+                modeHelp1 xs element (frequency + 1)
+
+            else
+                modeHelp2 xs element frequency x 1
+
+
+modeHelp2 : List b -> b -> number -> b -> number -> ( b, number )
+modeHelp2 rest best bestFreq new newFreq =
+    case rest of
+        [] ->
+            if newFreq > bestFreq then
+                ( new, newFreq )
+
+            else
+                ( best, bestFreq )
+
+        x :: xs ->
+            if x == new then
+                modeHelp2 xs best bestFreq new (newFreq + 1)
+
+            else if newFreq > bestFreq then
+                modeHelp2 rest new newFreq x 1
+
+            else
+                modeHelp2 xs best bestFreq x 1
+
+
+
+-- let
+--     frequencyTable =
+--         buildTable list
+--     maxValue =
+--         List.maximum (Dict.values frequencyTable)
+--     kvList =
+--         Dict.toList frequencyTable
+-- in
+-- List.filter (\( _, v ) -> Just v == maxValue) kvList
+--     |> List.head
+--     |> Maybe.map Tuple.first
+--     |> (\x -> ( x, maxValue ))
+--     |> combineTuple
 
 
 {-| Compute the median of the list. The median is the value separating the higher half from the lower half of a data sample. If the sample has an odd number of values, the median is the value in the middle. If the sample has an even number of values, the median is the mean of the two middle values.

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -231,23 +231,65 @@ modeHelp2 rest best bestFreq new newFreq =
 -}
 median : List Float -> Maybe Float
 median list =
-    let
-        l =
-            List.length list
-    in
-    if l == 0 then
-        Nothing
+    case list of
+        [] ->
+            Nothing
 
-    else if modBy 2 l == 0 then
-        List.sort list
-            |> List.drop ((l // 2) - 1)
-            |> List.take 2
-            |> mean
+        _ :: xs ->
+            let
+                length : number
+                length =
+                    lengthHelp xs 1
+            in
+            if modBy 2 length == 0 then
+                case
+                    List.sort list
+                        |> List.drop ((length // 2) - 1)
+                of
+                    x :: y :: _ ->
+                        Just <| (x + y) / 2
 
-    else
-        List.sort list
-            |> List.drop (l // 2)
-            |> List.head
+                    _ ->
+                        Nothing
+
+            else
+                case
+                    List.sort list
+                        |> List.drop (length // 2)
+                of
+                    x :: _ ->
+                        Just x
+
+                    _ ->
+                        Nothing
+
+
+lengthHelp : List a -> number -> number
+lengthHelp remaining total =
+    case remaining of
+        [] ->
+            total
+
+        _ :: xs ->
+            lengthHelp xs (total + 1)
+
+
+
+-- let
+--     l =
+--         List.length list
+-- in
+-- if l == 0 then
+--     Nothing
+-- else if modBy 2 l == 0 then
+--     List.sort list
+--         |> List.drop ((l // 2) - 1)
+--         |> List.take 2
+--         |> mean
+-- else
+--     List.sort list
+--         |> List.drop (l // 2)
+--         |> List.head
 
 
 {-| Root mean square (RMS) is the square root of the sum of the squares of values in a list divided by the length of the list. Also known as quadratic mean.

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -430,7 +430,38 @@ zScore x avg stdDev =
 -}
 zScores : List Float -> Maybe (List Float)
 zScores list =
-    Maybe.map2 (\avg stdDev -> List.map (\x -> (x - avg) / stdDev) list) (mean list) (standardDeviation list)
+    case list of
+        [] ->
+            Nothing
+
+        head :: rest ->
+            zScoresHelp1 rest (head ^ 2) head 1 [ head ]
+                |> Just
+
+
+zScoresHelp1 : List Float -> Float -> Float -> Float -> List Float -> List Float
+zScoresHelp1 remaining squaredSum sum length reversed =
+    case remaining of
+        [] ->
+            let
+                avg : Float
+                avg =
+                    sum / length
+            in
+            zScoresHelp2 avg (sqrt (squaredSum / length - avg ^ 2)) reversed []
+
+        x :: xs ->
+            zScoresHelp1 xs (squaredSum + x ^ 2) (sum + x) (length + 1) (x :: reversed)
+
+
+zScoresHelp2 : Float -> Float -> List Float -> List Float -> List Float
+zScoresHelp2 avg stdDev remaining acc =
+    case remaining of
+        [] ->
+            acc
+
+        x :: xs ->
+            zScoresHelp2 avg stdDev xs (((x - avg) / stdDev) :: acc)
 
 
 {-| Covariance is a measure of how two random variables vary together. When the greater values of one variable correspond to the greater values of the other variable, this is a positive covariance. Whereas when the greater values of one variable correspond to the lesser values of the other variable, this is negative covariance.

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -475,12 +475,46 @@ zScoresHelp2 avg stdDev remaining acc =
 -}
 covariance : List ( Float, Float ) -> Maybe Float
 covariance tupleList =
-    let
-        ( xs, ys ) =
-            List.unzip tupleList
-    in
-    Maybe.map2 (\mxs mys -> List.map2 (\x y -> (x - mxs) * (y - mys)) xs ys) (mean xs) (mean ys)
-        |> Maybe.andThen mean
+    case tupleList of
+        [] ->
+            Nothing
+
+        ( a, b ) :: xs ->
+            let
+                { meanA, meanB, length } =
+                    covarianceHelp1 xs a b 1
+            in
+            covarianceHelp2 xs meanA meanB ((a - meanA) * (b - meanB))
+                / length
+                |> Just
+
+
+covarianceHelp1 :
+    List ( Float, Float )
+    -> Float
+    -> Float
+    -> Float
+    -> { meanA : Float, meanB : Float, length : Float }
+covarianceHelp1 remaining sumA sumB length =
+    case remaining of
+        [] ->
+            { meanA = sumA / length
+            , meanB = sumB / length
+            , length = length
+            }
+
+        ( a, b ) :: xs ->
+            covarianceHelp1 xs (sumA + a) (sumB + b) (length + 1)
+
+
+covarianceHelp2 : List ( Float, Float ) -> Float -> Float -> Float -> Float
+covarianceHelp2 remaining meanA meanB acc =
+    case remaining of
+        [] ->
+            acc
+
+        ( a, b ) :: xs ->
+            covarianceHelp2 xs meanA meanB (acc + (a - meanA) * (b - meanB))
 
 
 {-| A correlation is a “normalized” covariance, its values are between -1.0 and 1.0

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -152,15 +152,22 @@ harmonicMeanHelp remaining inverseSum length =
 -}
 geometricMean : List Float -> Maybe Float
 geometricMean list =
-    let
-        l =
-            List.length list
-    in
-    if l == 0 then
-        Nothing
+    case list of
+        [] ->
+            Nothing
 
-    else
-        List.product list ^ (1 / toFloat l) |> Just
+        x :: xs ->
+            Just (geometricMeanHelp xs x 1)
+
+
+geometricMeanHelp : List Float -> Float -> Float -> Float
+geometricMeanHelp remaining product length =
+    case remaining of
+        [] ->
+            product ^ (1 / length)
+
+        x :: xs ->
+            geometricMeanHelp xs (product * x) (length + 1)
 
 
 {-| Compute the mode of the data:

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -75,12 +75,12 @@ average =
 -}
 meanWithDefault : List Float -> Float -> Float
 meanWithDefault list defaultValue =
-    case mean list of
-        Nothing ->
+    case list of
+        [] ->
             defaultValue
 
-        Just val ->
-            val
+        x :: xs ->
+            meanHelp xs x 1
 
 
 {-| Compute the weighted mean of a list of tuples, where the first elemnt in the tuple is the weight and the second is the value

--- a/src/Stat.elm
+++ b/src/Stat.elm
@@ -29,7 +29,7 @@ module Stat exposing
 
 -}
 
-import Dict as Dict
+import Dict
 import Utility exposing (buildTable, combineTuple)
 
 
@@ -41,20 +41,22 @@ import Utility exposing (buildTable, combineTuple)
 -}
 mean : List Float -> Maybe Float
 mean list =
-    let
-        ( sum, len ) =
-            sumLen list
-    in
-    if len == 0 then
-        Nothing
+    case list of
+        [] ->
+            Nothing
 
-    else
-        sum / toFloat len |> Just
+        x :: xs ->
+            Just (meanHelp xs x 1)
 
 
-sumLen : List Float -> ( Float, Int )
-sumLen =
-    List.foldl (\x y -> Tuple.pair (Tuple.first y + x) (Tuple.second y + 1)) ( 0, 0 )
+meanHelp : List Float -> Float -> Float -> Float
+meanHelp remaining total length =
+    case remaining of
+        [] ->
+            total / length
+
+        x :: rest ->
+            meanHelp rest (total + x) (length + 1)
 
 
 {-| Same as mean

--- a/tests/StatTests.elm
+++ b/tests/StatTests.elm
@@ -197,13 +197,31 @@ varianceTest =
             (\_ -> Expect.within (Absolute 0.01) 2 (Stat.variance ys |> Maybe.withDefault 0))
         , test "test for empty list"
             (\_ -> Expect.equal Nothing (Stat.variance emp))
+        , fuzz (list (floatRange -100 100)) "generating a list of floats" <|
+            \floatList ->
+                case Stat.variance floatList of
+                    Nothing ->
+                        Expect.equal floatList []
+
+                    Just n ->
+                        let
+                            mean list =
+                                List.sum list / toFloat (List.length list)
+
+                            squared =
+                                List.map (\x -> x ^ 2) floatList
+
+                            variance =
+                                mean squared - mean floatList ^ 2
+                        in
+                        Expect.within (Absolute 0.000000001) n variance
         ]
 
 
 standardDeviationFuzzTest : Test
 standardDeviationFuzzTest =
     describe "standard deviation fuzz test"
-        [ fuzz (list niceFloat) "generating a list of floats" <|
+        [ fuzz (list (floatRange -100 100)) "generating a list of floats" <|
             \floatList ->
                 let
                     var =

--- a/tests/StatTests.elm
+++ b/tests/StatTests.elm
@@ -11,13 +11,16 @@ meanFuzzTest =
     describe "mean fuzz test"
         [ fuzz (list float) "generating a list of floats" <|
             \floatList ->
-                floatList
-                    |> Stat.mean
-                    |> Maybe.withDefault 0
-                    |> Expect.all
-                        [ Expect.atLeast (List.minimum floatList |> Maybe.withDefault 0)
-                        , Expect.atMost (List.maximum floatList |> Maybe.withDefault 0)
-                        ]
+                case Stat.mean floatList of
+                    Nothing ->
+                        Expect.equal floatList []
+
+                    Just avg ->
+                        Expect.all
+                            [ Expect.atLeast (List.minimum floatList |> Maybe.withDefault 0)
+                            , Expect.atMost (List.maximum floatList |> Maybe.withDefault 0)
+                            ]
+                            avg
         ]
 
 

--- a/tests/StatTests.elm
+++ b/tests/StatTests.elm
@@ -9,7 +9,7 @@ import Test exposing (..)
 meanFuzzTest : Test
 meanFuzzTest =
     describe "mean fuzz test"
-        [ fuzz (list float) "generating a list of floats" <|
+        [ fuzz (list niceFloat) "generating a list of floats" <|
             \floatList ->
                 case Stat.mean floatList of
                     Nothing ->
@@ -115,7 +115,7 @@ modeTest =
 medianFuzzTest : Test
 medianFuzzTest =
     describe "median fuzz test"
-        [ fuzz (list float) "generating a list of floats" <|
+        [ fuzz (list niceFloat) "generating a list of floats" <|
             \floatList ->
                 floatList
                     |> Stat.median
@@ -194,7 +194,7 @@ varianceTest =
 standardDeviationFuzzTest : Test
 standardDeviationFuzzTest =
     describe "standard deviation fuzz test"
-        [ fuzz (list float) "generating a list of floats" <|
+        [ fuzz (list niceFloat) "generating a list of floats" <|
             \floatList ->
                 let
                     var =

--- a/tests/StatTests.elm
+++ b/tests/StatTests.elm
@@ -17,8 +17,17 @@ meanFuzzTest =
 
                     Just avg ->
                         Expect.all
-                            [ Expect.atLeast (List.minimum floatList |> Maybe.withDefault 0)
-                            , Expect.atMost (List.maximum floatList |> Maybe.withDefault 0)
+                            [ Expect.atLeast
+                                (List.minimum floatList |> Maybe.withDefault 0)
+                            , Expect.atMost
+                                (List.maximum floatList |> Maybe.withDefault 0)
+                            , let
+                                naiveMean : Float
+                                naiveMean =
+                                    List.sum floatList
+                                        / toFloat (List.length floatList)
+                              in
+                              Expect.within (Absolute 0.000000001) naiveMean
                             ]
                             avg
         ]

--- a/tests/StatTests.elm
+++ b/tests/StatTests.elm
@@ -1,8 +1,8 @@
-module FuzzTests exposing (correlationTest, covarianceTest, geometricMeanTest, harmonicMeanTest, linearRegressionTest, meanAbsoluteDeviationTest, meanFuzzTest, medianAbsoluteDeviationTest, medianFuzzTest, modeTest, rootMeanSquareFuzzTest, skewnessTest, standardDeviationFuzzTest, varianceTest, weightedMeanTest, zScoreTest, zScoresTest)
+module StatTests exposing (correlationTest, covarianceTest, geometricMeanTest, harmonicMeanTest, linearRegressionTest, meanAbsoluteDeviationTest, meanFuzzTest, medianAbsoluteDeviationTest, medianFuzzTest, modeTest, rootMeanSquareFuzzTest, skewnessTest, standardDeviationFuzzTest, varianceTest, weightedMeanTest, zScoreTest, zScoresTest)
 
 import Expect exposing (Expectation, FloatingPointTolerance(..))
 import Fuzz exposing (..)
-import Stat as Stat
+import Stat
 import Test exposing (..)
 
 


### PR DESCRIPTION
Hi, thanks for making elm-stat! 😁 

I made some optimizations to the `Stat` module, added a couple of tests and added the `benchmarks` folder with the results of the optmizations.

You can see the improvements by running `cd benchmarks && elm make src/Benchmarks.elm --optimize` and opening the `index.html` file in a browser. It will probably freeze for a few seconds and then start benchmarking.

The optimizations mostly rely on the tail call optimization made by the Elm compiler, I also eliminated some redundant list traversals. For example, mean and variance can be computed in a single pass over a list.

I hope this is helpful!