### PR TITLE
Update dependencies

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "jxxcarlson/elm-stat",
     "summary": "Elm stat utility",
     "license": "BSD-3-Clause",
-    "version": "6.0.2",
+    "version": "6.0.3",
     "exposed-modules": [
         "StatRandom",
         "Stat",
@@ -19,8 +19,8 @@
         "elm/core": "1.0.2 <= v < 2.0.0",
         "elm/parser": "1.1.0 <= v < 2.0.0",
         "elm/random": "1.0.0 <= v < 2.0.0",
-        "elm-community/typed-svg": "6.0.0 <= v < 7.0.0",
-        "folkertdev/one-true-path-experiment": "4.0.2 <= v < 5.0.0",
+        "elm-community/typed-svg": "7.0.0 <= v < 8.0.0",
+        "folkertdev/one-true-path-experiment": "6.0.0 <= v < 7.0.0",
         "gampleman/elm-visualization": "2.0.0 <= v < 3.0.0",
         "zgohr/elm-csv": "1.0.1 <= v < 2.0.0"
     },


### PR DESCRIPTION
We wanted to use this package at work but the dependency on an old version of one-true-path-experiment meant that it was incompatible with the current version of elm-geometry - I think this change brings elm-stat up to date with the current versions of all dependencies.